### PR TITLE
Remove duplication in the converter output. Improve performance.

### DIFF
--- a/src/org/ld4l/bib2lod/rdfconversion/BibframeConverter.java
+++ b/src/org/ld4l/bib2lod/rdfconversion/BibframeConverter.java
@@ -239,7 +239,9 @@ public class BibframeConverter extends RdfProcessor {
 
                 // appendModelToFile(converter.convert(subject), outputFile);
                 
-                outputModel.add(converter.convert(subject));
+				Model addModel = converter.convert(subject);
+				outputModel.add(addModel);
+				addModel.removeAll();
 
 //                if (subjectCountToWrite >= 1000) {
 //                    LOGGER.debug("Appending RDF for " + subjectCountToWrite                              


### PR DESCRIPTION
Test case 1:
input: 262,739 triples (10 files)
output: 191,751 triples
elapsed time: before: 2:13; after: 0:40

Test case 2:
input: 1,291,140 triples (50 files)
output: 914,403 triples
elapsed time: before: 46:40; after: 2:46

Test case 3:
input: 6,429,072 triples (248 files)
output: 4,410,702 triples
elapsed time: before: 15:20:47; after: 12:17
